### PR TITLE
Filter constructor dependency injection

### DIFF
--- a/djomo-rs/pom.xml
+++ b/djomo-rs/pom.xml
@@ -27,7 +27,7 @@
 	<artifactId>djomo-rs</artifactId>
 	<packaging>jar</packaging>
 
-	<name>djomo-rs :: dynamic json I/O models for JAX-RS</name>
+	<name>djomo-rs :: dynamic json models for JAX-RS</name>
 	<description>JAX-RS EntityProviders for producing and consuming json using djomo</description>
 
 	<dependencies>

--- a/djomo/pom.xml
+++ b/djomo/pom.xml
@@ -27,7 +27,7 @@
 	<artifactId>djomo</artifactId>
 	<packaging>jar</packaging>
 
-	<name>djomo :: dynamic json I/O models for Java</name>
+	<name>djomo :: dynamic json models for Java</name>
 	<description>a small, fast and extensible java library for reading and writing JSON and performing data transformations</description>
 
 	<properties>

--- a/djomo/src/main/java/com/bigcloud/djomo/base/AnnotationProcessor.java
+++ b/djomo/src/main/java/com/bigcloud/djomo/base/AnnotationProcessor.java
@@ -50,9 +50,11 @@ public class AnnotationProcessor {
 	private final ConcurrentHashMap<Visit, FilterVisitor> visitors = new ConcurrentHashMap<>();
 	private final ConcurrentHashMap<Parse, FilterParser> parsers = new ConcurrentHashMap<>();
 	private final Models models;
+	private final Object[] dependencies;
 	
-	public AnnotationProcessor(Models models) {
+	public AnnotationProcessor(Models models, Object... dependencies) {
 		this.models = models;
+		this.dependencies = dependencies.clone();
 	}
 
 	public FilterVisitor[] visitorFilters(Class<?> type) {
@@ -146,6 +148,7 @@ public class AnnotationProcessor {
 			boolean foundType = false;
 			Object[] values = new Object[parms.length];
 			int argPointer = 0;
+			PARM_LOOP:
 			for(int i=0; i<parms.length; i++) {
 				Parameter parm = parms[i];
 				Class parmType = parm.getType();
@@ -184,6 +187,12 @@ public class AnnotationProcessor {
 					argPointer = args.length;
 				}
 				else {
+					for(Object d: dependencies) {
+						if(parmType.isInstance(d)) {
+							values[i] = d;
+							continue PARM_LOOP;
+						}
+					}
 					continue CONSTRUCTOR_SEARCH;
 				}
 			}

--- a/djomo/src/main/java/com/bigcloud/djomo/base/AnnotationProcessor.java
+++ b/djomo/src/main/java/com/bigcloud/djomo/base/AnnotationProcessor.java
@@ -32,6 +32,7 @@ import com.bigcloud.djomo.annotation.Parses;
 import com.bigcloud.djomo.annotation.Visit;
 import com.bigcloud.djomo.annotation.Visits;
 import com.bigcloud.djomo.api.Model;
+import com.bigcloud.djomo.error.AnnotationException;
 import com.bigcloud.djomo.filter.FilterParser;
 import com.bigcloud.djomo.filter.FilterVisitor;
 import com.bigcloud.djomo.filter.PathParser;
@@ -101,6 +102,25 @@ public class AnnotationProcessor {
 		return parserFilters.toArray(new FilterParser[0]);
 	}
 
+	private void missingConstructor(Class<?> filterClass) throws InstantiationException {
+		StringBuilder messageBuilder = new StringBuilder("No matching constructor for ").append(filterClass.getName()).append(" ; try adding args or injecting dependencies to mmatch a constructor [");
+		for(Constructor c : filterClass.getConstructors()) {
+			messageBuilder.append("\n\t").append(filterClass.getSimpleName()).append("(");
+			boolean first = true;
+			for(Parameter p: c.getParameters()) {
+				if(first) {
+					first = false;
+				}
+				else {
+					messageBuilder.append(", ");
+				}
+				messageBuilder.append(p.getParameterizedType().getTypeName()).append(" ").append(p.getName());
+			}
+			messageBuilder.append(")");
+		}
+		messageBuilder.append("\n]");
+		throw new InstantiationException(messageBuilder.toString());
+	}
 	private void configure(Parse deser, ArrayDeque<FilterParser> filters,
 			PathParser.Builder pathBuilder) {
 		try {
@@ -112,7 +132,7 @@ public class AnnotationProcessor {
 				if (filterParser == null) {
 					filterParser = (FilterParser) typedFilter(filterClass, null, deser.arg());
 					if(filterParser == null) {
-						throw new IllegalArgumentException("No suitable constructor found for "+filterClass.getName());
+						missingConstructor(filterClass);
 					}
 					if (filterType != Object.class) {
 						filterParser = new TypeParser<>(filterType, filterParser);
@@ -134,8 +154,7 @@ public class AnnotationProcessor {
 			}
 		} catch (InstantiationException | IllegalAccessException | IllegalArgumentException
 				| InvocationTargetException | SecurityException e) {
-			throw new RuntimeException("Error instantiating ParserFilter " + deser.value().getName()
-					+ " with arguments " + Arrays.toString(deser.arg()), e);
+			throw new AnnotationException("Unable to make FilterParser from annotation " + deser, e);
 		}
 	}
 
@@ -214,7 +233,7 @@ public class AnnotationProcessor {
 				if (filterVisitor == null) {
 					filterVisitor = (FilterVisitor) typedFilter(filterClass, null, ser.arg());
 					if(filterVisitor == null) {
-						throw new IllegalArgumentException("No suitable constructor found for "+filterClass.getName());
+						missingConstructor(filterClass);
 					}
 					if (filterType != Object.class) {
 						filterVisitor = new TypeVisitor<>(filterType, filterVisitor);
@@ -235,8 +254,7 @@ public class AnnotationProcessor {
 			}
 		} catch (InstantiationException | IllegalAccessException | IllegalArgumentException
 				| InvocationTargetException | SecurityException e) {
-			throw new RuntimeException("Error instantiating VisitorFilter " + ser.value().getName() + " with arguments "
-					+ Arrays.toString(ser.arg()), e);
+			throw new AnnotationException("Unable to make FilterVisitor from annotation " + ser, e);
 		}
 	}
 

--- a/djomo/src/main/java/com/bigcloud/djomo/error/AnnotationException.java
+++ b/djomo/src/main/java/com/bigcloud/djomo/error/AnnotationException.java
@@ -1,0 +1,10 @@
+package com.bigcloud.djomo.error;
+
+public class AnnotationException extends RuntimeException {
+	public AnnotationException(String string, Exception e) {
+		super(string, e);
+	}
+
+	private static final long serialVersionUID = -8673809847005929255L;
+
+}

--- a/djomo/src/main/java/com/bigcloud/djomo/error/AnnotationException.java
+++ b/djomo/src/main/java/com/bigcloud/djomo/error/AnnotationException.java
@@ -1,3 +1,18 @@
+/*******************************************************************************
+ * Copyright 2022 Alex Vigdor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
 package com.bigcloud.djomo.error;
 
 public class AnnotationException extends RuntimeException {

--- a/djomo/src/main/java/com/bigcloud/djomo/object/BeanModel.java
+++ b/djomo/src/main/java/com/bigcloud/djomo/object/BeanModel.java
@@ -47,7 +47,7 @@ public class BeanModel<T> extends ObjectMethodsModel<T, BeanMaker<T>> {
 		try {
 			return (T) constructor.invoke();
 		} catch (Throwable e) {
-			throw new RuntimeException("Unable to create instance of "+type.getName(), e);
+			throw new RuntimeException("Unable to create instance of " + type.getName(), e);
 		}
 	}
 

--- a/djomo/src/test/java/com/bigcloud/djomo/test/FilterTest.java
+++ b/djomo/src/test/java/com/bigcloud/djomo/test/FilterTest.java
@@ -34,6 +34,7 @@ import com.bigcloud.djomo.StaticType;
 import com.bigcloud.djomo.annotation.Parse;
 import com.bigcloud.djomo.annotation.Visit;
 import com.bigcloud.djomo.api.Model;
+import com.bigcloud.djomo.error.AnnotationException;
 import com.bigcloud.djomo.filter.CircularReferenceVisitor;
 import com.bigcloud.djomo.filter.ExcludeParser;
 import com.bigcloud.djomo.filter.ExcludeVisitor;
@@ -245,6 +246,11 @@ public class FilterTest {
 		Assert.assertEquals(rt, things);
 	}
 
+	@Test(expectedExceptions = AnnotationException.class)
+	public void testMissingVisitorInjection() throws IOException {
+		Json.builder().scan(DaoLoader.class).build();
+	}
+
 	@Visit(DaoLoader.class)
 	public static class DaoLoader extends TypeVisitorTransform<UUID> {
 		final Dao dao;
@@ -269,6 +275,22 @@ public class FilterTest {
 
 		public void put(UUID id, T obj) {
 			data.put(id, obj);
+		}
+	}
+
+	@Test(expectedExceptions = AnnotationException.class)
+	public void testMissingParserInjection() throws IOException {
+		Json.builder().scan(TroubleMaker.class).build();
+	}
+
+	@Parse(TroubleMaker.class)
+	public static class TroubleMaker extends FilterParser {
+		public TroubleMaker(String name) {
+
+		}
+
+		public TroubleMaker(Dao dao, String name) {
+
 		}
 	}
 }

--- a/djomo/src/test/java/com/bigcloud/djomo/test/RecordTest.java
+++ b/djomo/src/test/java/com/bigcloud/djomo/test/RecordTest.java
@@ -24,29 +24,29 @@ import com.bigcloud.djomo.Json;
 import com.bigcloud.djomo.Models;
 import com.bigcloud.djomo.annotation.Order;
 import com.bigcloud.djomo.api.Field;
-import com.bigcloud.djomo.api.ModelContext;
 import com.bigcloud.djomo.api.ObjectMaker;
 import com.bigcloud.djomo.api.ObjectModel;
 
 public class RecordTest {
-	Models Models = new Models();
-	Json Json = new Json(Models);
+	Models models = new Models();
+	Json json = new Json(models);
+
 	@Test
 	public void testRecords() throws IOException {
 		Envelope envelope = new Envelope(13, "you", new Message("Testing", "Are you there?"));
-		String json = Json.toString(envelope);
-		Envelope roundTrip = Json.fromString(json, Envelope.class);
+		String out = json.toString(envelope);
+		Envelope roundTrip = json.fromString(out, Envelope.class);
 		Assert.assertEquals(roundTrip, envelope);
 		envelope = new Envelope(888, "me", new Message("Made it", "In the shade"));
-		json = Json.toString(envelope);
-		roundTrip = Json.fromString(json, Envelope.class);
+		out = json.toString(envelope);
+		roundTrip = json.fromString(out, Envelope.class);
 		Assert.assertEquals(roundTrip, envelope);
 	}
 
 	@Test
-	public <F extends Field<Envelope,?,Object>> void testMaker() {
+	public <F extends Field<Envelope, ?, Object>> void testMaker() {
 		Envelope envelope = new Envelope(13, "you", new Message("Testing", "Are you there?"));
-		var em = ((ObjectModel<Envelope,ObjectMaker<Envelope,F,Object>,F, ?, Object>)Models.get(Envelope.class));
+		var em = ((ObjectModel<Envelope, ObjectMaker<Envelope, F, Object>, F, ?, Object>) models.get(Envelope.class));
 		var maker = em.maker(envelope);
 		maker.field(em.getField("id"), 99);
 		envelope = maker.make();
@@ -56,7 +56,7 @@ public class RecordTest {
 
 	@Test(expectedExceptions = RuntimeException.class)
 	public void testBadRecord() throws IOException {
-		((ObjectModel)Models.get(Envelope.class)).maker().make();
+		((ObjectModel) models.get(Envelope.class)).maker().make();
 	}
 
 	@Order({ "id", "to" })
@@ -66,4 +66,17 @@ public class RecordTest {
 	@Order({ "subject", "body" })
 	public static record Message(String subject, String body) {
 	};
+
+	@Test
+	public void testVirtualField() {
+		Extended extended = new Extended(123, "Hello World");
+		String out = json.toString(extended);
+		Assert.assertEquals(out, "{\"id\":123,\"name\":\"Hello World\",\"nameLength\":11}");
+	}
+
+	public static record Extended(int id, String name) {
+		public int getNameLength() {
+			return name == null ? 0 : name.length();
+		}
+	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 	<packaging>pom</packaging>
 	<version>0.9.1-SNAPSHOT</version>
 
-	<name>djomo-core :: dynamic json I/O models for Java and JAX-RS</name>
+	<name>djomo-core :: dynamic json models for Java and JAX-RS</name>
 	<description>Parent project for djomo and djomo-rs libraries</description>
 	<url>https://github.com/alexvigdor/djomo-core</url>
 


### PR DESCRIPTION
Add ability to inject application dependencies into a Json builder that can be passed through to filter constructors when processing annotations